### PR TITLE
Bind Tor SOCKS port to localhost to avoid open proxy

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -32,7 +32,7 @@ chown -R "$USER:$GROUP" "$ONION_DIR"
 umask "$UMASK"
 
 # Configure torrc
-echo "SocksPort 0.0.0.0:9050" > "$TORRC"
+echo "SocksPort 127.0.0.1:9050" > "$TORRC"
 echo "HiddenServiceDir $ONION_DIR" >> "$TORRC"
 echo "HiddenServicePort 80 $ONION_PORT" >> "$TORRC"
 


### PR DESCRIPTION
### Motivation
- The startup script wrote `SocksPort 0.0.0.0:9050` into Tor's configuration which creates an unauthenticated SOCKS proxy bound to all interfaces and can be abused if the container port is published.

### Description
- Replace `SocksPort 0.0.0.0:9050` with `SocksPort 127.0.0.1:9050` in `start.sh` so Tor listens on loopback only while preserving the existing onion service setup.

### Testing
- Ran `bash -n start.sh` to confirm there are no shell syntax errors and the script remains valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d42a92b5ac832f8cd335add15600d9)